### PR TITLE
Use https for the demo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This addon is used to show [Contrast](https://www.contrast.app) handoff tool in 
 
 [Check out a demo here :)](https://contrastapp.wistia.com/medias/w71tocgxnm)
 
-![Demo](http://contrast-prod.s3.amazonaws.com/demo.png)
+![Demo](https://contrast-prod.s3.amazonaws.com/demo.png)
 
 -   [Getting Started](#getting-started)
     -   [Install using preset](#install-using-preset)


### PR DESCRIPTION
I'm one of the maintainers of the Storybook addons catalog. I noticed that you are using `http` for one of your images in the Readme. Since we render your Readme in the catalog, it throws insecure mixed content warnings. I switched the url to `https` to fix this issue.

It would be great if you could merge this and push out a new release (the catalog crawls npm releases). 